### PR TITLE
increasing timeout to handle CI/CD having to pull images

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,5 +1,5 @@
 export default {
   testEnvironment: 'node',
-  testTimeout: 20000,
+  testTimeout: 40000,
   verbose: true,
 };


### PR DESCRIPTION
A previous pipeline took ~25seconds to pull the mongo image which was all happening while Jest was waiting. This caused the test to go over the timeout threshold. This MR increases the threshold to account for slower CI runs which have to first pull the mongo image.