### PR TITLE
dropping alpha version of docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ docker inspect --format "{{json .State.Health }}" url-shortener-database-1 | jq
 Then in another terminal, start watching for source file changes to have them replicated into running containers:
 
 ```sh
-docker compose alpha watch
+docker compose watch
 ```
 
 ## Further Information

--- a/compose.yml
+++ b/compose.yml
@@ -36,7 +36,7 @@ services:
       database:
         condition: service_healthy
         restart: true
-    x-develop:
+    develop:
       watch:
         - action: sync
           path: ./src


### PR DESCRIPTION
Fixes #4.

The official linux apt sources only has surpassed version 2.22 of Docker Compose and there is no longer any need to use the `x-develop` key within the `compose.yml` file and no longer any need to use the `alpha` keyword when triggering watch (via `docker compose watch`)